### PR TITLE
Fix PUT /api/v1/messages/{messageId} not persisting changes

### DIFF
--- a/app/api/namespaces/messages.py
+++ b/app/api/namespaces/messages.py
@@ -192,13 +192,67 @@ class MessageResource(Resource):
         Returns:
             The updated message data
         """
+        from app.utils.db import session_scope
+
         try:
-            message_service = get_message_service()
             content = request.json.get("content")
-            message = message_service.update_message(message_id, content)
+
+            with session_scope() as session:
+                # Create message service with the scoped session
+                from app.repositories.ai_model_repository import AIModelRepository
+                from app.repositories.application_settings_repository import (
+                    ApplicationSettingsRepository,
+                )
+                from app.repositories.chat_session_repository import (
+                    ChatSessionRepository,
+                )
+                from app.repositories.message_repository import MessageRepository
+                from app.repositories.system_prompt_repository import (
+                    SystemPromptRepository,
+                )
+                from app.repositories.user_profile_repository import (
+                    UserProfileRepository,
+                )
+                from app.services.application_settings_service import (
+                    ApplicationSettingsService,
+                )
+                from app.services.message_service import MessageService
+                from app.services.openrouter.client import OpenRouterClient
+
+                message_repo = MessageRepository(session)
+                chat_session_repo = ChatSessionRepository(session)
+
+                # Create settings service
+                settings_repo = ApplicationSettingsRepository(session)
+                settings_service = ApplicationSettingsService(
+                    settings_repo,
+                    AIModelRepository(session),
+                    SystemPromptRepository(session),
+                    UserProfileRepository(session),
+                )
+
+                # Create OpenRouter client with API key
+                api_key = settings_service.get_openrouter_api_key()
+                if not api_key:
+                    openrouter_client = None
+                else:
+                    openrouter_client = OpenRouterClient(api_key=api_key)
+
+                message_service = MessageService(
+                    message_repo,
+                    chat_session_repo,
+                    settings_service=settings_service,
+                    openrouter_client=openrouter_client,
+                )
+
+                message = message_service.update_message(message_id, content)
+
+                # Format the response while the session is still active
+                response_data = format_message_data(message)
+
             return {
                 "success": True,
-                "data": format_message_data(message),
+                "data": response_data,
             }
         except ValidationError as e:
             return error_response(400, e.message, "VALIDATION_ERROR", e.details)


### PR DESCRIPTION
## Problem
The PUT endpoint for message updates was returning success responses but changes weren't persisting permanently in the database.

## Root Cause
The endpoint used `get_message_service()` which creates a session via `get_session()`, but this session never gets committed. The repository only calls `session.flush()` which sends changes to the database but doesn't commit the transaction.

## Solution
- Updated PUT endpoint to use `session_scope()` context manager (same pattern as DELETE endpoint)
- Moved response formatting inside the session scope to prevent detached instance errors
- Ensures proper transaction commit/rollback handling

## Testing
- ✅ Message updates now persist after API calls
- ✅ Validation and error handling still work correctly
- ✅ Changes are visible when fetching messages again

## Files Changed
- `app/api/namespaces/messages.py` - Updated PUT method in MessageResource class